### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.js]
+indent_size = 4
+indent_style = tab
+tab_width = 4


### PR DESCRIPTION
 - improves the github website aesthetics by showing 4 spaces instead of 8 when rendering tabs.